### PR TITLE
refactoring / DLC / `xlarge` / multi-contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,10 @@
 version: 2
 debug: true
-workflows:
-  version: 2
-  resource_class_jobs:
-    jobs:
-      - small
-      - medium
-      - medium-plus
-      - large
-  machine_jobs:
-    jobs:
-      - machine1
-      - remote_docker
-      - remote_docker_reusable
-  feature_jobs:
-    jobs:
-      - contexts:
-          context: org-global
-      - write_workspace
-      - use_workspace:
-          requires:
-            - write_workspace
-      - write_artifacts
 
+# yaml anchors
 resource-job-default: &resource-job-default
-  docker:
-    - image: circleci/ruby:2.4.1
-  steps:
-    - run: echo $CIRCLE_JOB
+  docker: [{image: 'circleci/ruby:2.4.1'}]
+  steps: [{run: 'echo $CIRCLE_JOB'}]
 
 machine: &machine
   machine: true
@@ -51,36 +28,33 @@ basic_docker_build: &basic_docker_build
     docker build -f $dockerfile --tag throwaway:$CIRCLE_BUILD_NUM .
     docker run --rm throwaway:$CIRCLE_BUILD_NUM
 
+workspaces: &workspaces
+  docker: [{image: 'circleci/node:latest'}]
+  working_directory: ~/foo/bar
+
 jobs:
+  # resource_class_jobs
   small:
     <<: *resource-job-default
     resource_class: small
+
   medium:
     <<: *resource-job-default
     resource_class: medium
+
   medium-plus:
     <<: *resource-job-default
     resource_class: medium+
+
   large:
     <<: *resource-job-default
     resource_class: large
 
+  # machine_jobs
   machine1:
     <<: *machine
     environment:
       SLEEP: 1
-
-  remote_docker_reusable:
-    <<: *remote_docker_executor
-    steps:
-      - run: which docker
-      - run: docker -v
-      - setup_remote_docker:
-          reusable: true
-          exclusive: false
-      - run:
-          <<: *basic_docker_build
-      - run: docker version
 
   remote_docker:
     <<: *remote_docker_executor
@@ -92,6 +66,25 @@ jobs:
           <<: *basic_docker_build
       - run: docker version
 
+  docker_layer_caching:
+    <<: *remote_docker_executor
+    steps:
+      - run: which docker
+      - run: docker -v
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          <<: *basic_docker_build
+      - run: docker version
+
+  machine_dlc:
+    machine:
+      docker_layer_caching: true
+    steps:
+      - run:
+          <<: *basic_docker_build
+
+  # feature_jobs
   contexts:
     docker:
       - image: alpine:latest
@@ -100,9 +93,7 @@ jobs:
       - run: env | grep CONTEXT_END_TO_END_TEST_VAR
 
   write_workspace:
-    docker:
-      - image: circleci/node:latest
-    working_directory: ~/foo/bar/
+    <<: *workspaces
     steps:
       - run: mkdir stuff
       - run: echo 5 >./stuff/thing
@@ -110,10 +101,9 @@ jobs:
           root: .
           paths:
             - stuff
+
   use_workspace:
-    docker:
-      - image: circleci/node:latest
-    working_directory: ~/foo/bar/
+    <<: *workspaces
     steps:
       - attach_workspace:
            at: ./attached
@@ -125,12 +115,14 @@ jobs:
             echo 'Yay, value matches'
             exit 0
           fi
+
   write_artifacts:
     docker:
       - image: python:3.6.0
     working_directory: ~/realitycheck
     steps:
       - checkout
+
       - run:
           name: Creating Dummy Artifacts
           command: |
@@ -148,3 +140,30 @@ jobs:
       - store_test_results:
           path: test-results
 
+# workflows
+workflows:
+  version: 2
+
+  resource_class_jobs:
+    jobs:
+      - small
+      - medium
+      - medium-plus
+      - large
+
+  machine_jobs:
+    jobs:
+      - machine1
+      - remote_docker
+      - docker_layer_caching
+      - machine_dlc
+
+  feature_jobs:
+    jobs:
+      - contexts:
+          context: org-global
+      - write_workspace
+      - use_workspace:
+          requires:
+            - write_workspace
+      - write_artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,11 @@ jobs:
     machine:
       docker_layer_caching: true
     steps:
+      - run: which docker
+      - run: docker -v
       - run:
           <<: *basic_docker_build
+      - run: docker version
 
   # feature jobs
   contexts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,11 @@
 version: 2
 debug: true
 
-# yaml anchors
-resource-job-default: &resource-job-default
+resource_job_defaults: &resource_job_defaults
   docker: [{image: 'circleci/ruby:2.4.1'}]
   steps: [{run: 'echo $CIRCLE_JOB'}]
 
-machine: &machine
-  machine: true
-  steps:
-    - run: |
-        echo $SLEEP
-        date
-        sleep $SLEEP
-        date
-        echo 'Done sleeping.'
-
-remote_docker_executor: &remote_docker_executor
+remote_docker_defaults: &remote_docker_defaults
   docker: [{image: 'docker:17.06-git'}]
 
 basic_docker_build: &basic_docker_build
@@ -28,36 +17,43 @@ basic_docker_build: &basic_docker_build
     docker build -f $dockerfile --tag throwaway:$CIRCLE_BUILD_NUM .
     docker run --rm throwaway:$CIRCLE_BUILD_NUM
 
-workspaces: &workspaces
+workspaces_defaults: &workspaces_defaults
   docker: [{image: 'circleci/node:latest'}]
   working_directory: ~/foo/bar
 
 jobs:
-  # resource_class_jobs
+  # resource class jobs
   small:
-    <<: *resource-job-default
+    <<: *resource_job_defaults
     resource_class: small
 
   medium:
-    <<: *resource-job-default
+    <<: *resource_job_defaults
     resource_class: medium
 
   medium-plus:
-    <<: *resource-job-default
+    <<: *resource_job_defaults
     resource_class: medium+
 
   large:
-    <<: *resource-job-default
+    <<: *resource_job_defaults
     resource_class: large
 
-  # machine_jobs
-  machine1:
-    <<: *machine
+  # vm jobs
+  machine:
+    machine: true
+    steps:
+      - run: |
+          echo $SLEEP
+          date
+          sleep $SLEEP
+          date
+          echo 'Done sleeping.'
     environment:
       SLEEP: 1
 
   remote_docker:
-    <<: *remote_docker_executor
+    <<: *remote_docker_defaults
     steps:
       - run: which docker
       - run: docker -v
@@ -67,7 +63,7 @@ jobs:
       - run: docker version
 
   docker_layer_caching:
-    <<: *remote_docker_executor
+    <<: *remote_docker_defaults
     steps:
       - run: which docker
       - run: docker -v
@@ -84,7 +80,7 @@ jobs:
       - run:
           <<: *basic_docker_build
 
-  # feature_jobs
+  # feature jobs
   contexts:
     docker:
       - image: alpine:latest
@@ -93,7 +89,7 @@ jobs:
       - run: env | grep CONTEXT_END_TO_END_TEST_VAR
 
   write_workspace:
-    <<: *workspaces
+    <<: *workspaces_defaults
     steps:
       - run: mkdir stuff
       - run: echo 5 >./stuff/thing
@@ -103,7 +99,7 @@ jobs:
             - stuff
 
   use_workspace:
-    <<: *workspaces
+    <<: *workspaces_defaults
     steps:
       - attach_workspace:
            at: ./attached
@@ -140,10 +136,8 @@ jobs:
       - store_test_results:
           path: test-results
 
-# workflows
 workflows:
   version: 2
-
   resource_class_jobs:
     jobs:
       - small
@@ -151,9 +145,9 @@ workflows:
       - medium-plus
       - large
 
-  machine_jobs:
+  vm_jobs:
     jobs:
-      - machine1
+      - machine
       - remote_docker
       - docker_layer_caching
       - machine_dlc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,10 @@ jobs:
     <<: *resource_job_defaults
     resource_class: large
 
+  xlarge:
+    <<: *resource_job_defaults
+    resource_class: xlarge
+
   # vm jobs
   machine:
     machine: true
@@ -147,6 +151,7 @@ workflows:
       - medium
       - medium-plus
       - large
+      - xlarge
 
   vm_jobs:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
           paths:
             - stuff
 
-  use_workspace:
+  read_workspace:
     <<: *workspaces_defaults
     steps:
       - attach_workspace:
@@ -115,7 +115,7 @@ jobs:
             exit 0
           fi
 
-  write_artifacts:
+  artifacts_test_results:
     docker:
       - image: python:3.6.0
     working_directory: ~/realitycheck
@@ -160,7 +160,7 @@ workflows:
       - contexts:
           context: org-global
       - write_workspace
-      - use_workspace:
+      - read_workspace:
           requires:
             - write_workspace
-      - write_artifacts
+      - artifacts_test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ basic_docker_build: &basic_docker_build
     docker build -f $dockerfile --tag throwaway:$CIRCLE_BUILD_NUM .
     docker run --rm throwaway:$CIRCLE_BUILD_NUM
 
+contexts_defaults: &contexts_defaults
+  docker: [{image: 'alpine:latest'}]
+  working_directory: /a/contexts/test
+
 workspaces_defaults: &workspaces_defaults
   docker: [{image: 'circleci/node:latest'}]
   working_directory: ~/foo/bar
@@ -89,11 +93,14 @@ jobs:
 
   # feature jobs
   contexts:
-    docker:
-      - image: alpine:latest
-    working_directory: /a/contexts/test
+    <<: *contexts_defaults
     steps:
       - run: env | grep CONTEXT_END_TO_END_TEST_VAR
+
+  multi-contexts:
+    <<: *contexts_defaults
+    steps:
+      - run: env | grep MULTI_CONTEXT_END_TO_END_VAR
 
   write_workspace:
     <<: *workspaces_defaults
@@ -164,6 +171,8 @@ workflows:
     jobs:
       - contexts:
           context: org-global
+      - multi-contexts:
+          context: individual-local
       - write_workspace
       - read_workspace:
           requires:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A sample app that reality-checks some basic features on your installation of Cir
 1. Runs jobs using all known `resource_class` options (*NOTE:* your build instances must be large enough to accomodate these options—see our [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#resource_class) for details)
 2. Runs [machine executor](https://circleci.com/docs/2.0/executor-types/#using-machine) & [remote Docker](https://circleci.com/docs/2.0/building-docker-images) jobs, both with and without [Docker Layer Caching](https://circleci.com/docs/2.0/docker-layer-caching)
 3. Tests writing to and reading from [workspaces](https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs)
-4. Tests that the `org-global` [context](https://circleci.com/docs/2.0/contexts) is working (*NOTE:* needs a key called `CONTEXT_END_TO_END_TEST_VAR` to exist in the `org-global` context)
+4. Tests the default `org-global` [context](https://circleci.com/docs/2.0/contexts) (*NOTE:* needs a key called `CONTEXT_END_TO_END_TEST_VAR` to exist in the `org-global` context), along with one additional context (likewise needs a key called `MULTI_CONTEXT_END_TO_END_VAR` to exist in an `individual-local` context)
 5. Tests upload/storage of [artifacts](https://circleci.com/docs/2.0/artifacts) and [test results](https://circleci.com/docs/2.0/collect-test-data)
 
 To run realitycheck, fork the repository and start building it on your installation of CircleCI.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
  # realitycheck
 A sample app that reality checks some basic features on your installation of CircleCI:
-1. Runs all known `resource_class` options (*NOTE:* your build instances must be large enough to accomodate these options)
+1. Runs all known `resource_class` options (*NOTE:* your build instances must be large enough to accomodate these options—see our [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#resource_class) for details)
 2. Runs `machine` executor & `setup_remote_docker` builds, both with and without [Docker Layer Caching](https://circleci.com/docs/2.0/docker-layer-caching)
 3. Read/write workspaces
 4. Tests that the `org-global` context is working (*NOTE:* needs a key called `CONTEXT_END_TO_END_TEST_VAR` to exist in the `org-global` context)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
  # realitycheck
-A sample app that reality checks some basic features on your installation of CircleCI:
-1. Runs all known `resource_class` options (*NOTE:* your build instances must be large enough to accomodate these options—see our [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#resource_class) for details)
-2. Runs `machine` executor & `setup_remote_docker` builds, both with and without [Docker Layer Caching](https://circleci.com/docs/2.0/docker-layer-caching)
-3. Read/write workspaces
-4. Tests that the `org-global` context is working (*NOTE:* needs a key called `CONTEXT_END_TO_END_TEST_VAR` to exist in the `org-global` context)
-5. Tests writing artifacts
+A sample app that reality-checks some basic features on your installation of CircleCI:
+1. Runs jobs using all known `resource_class` options (*NOTE:* your build instances must be large enough to accomodate these options—see our [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#resource_class) for details)
+2. Runs [machine executor](https://circleci.com/docs/2.0/executor-types/#using-machine) & [remote Docker](https://circleci.com/docs/2.0/building-docker-images) jobs, both with and without [Docker Layer Caching](https://circleci.com/docs/2.0/docker-layer-caching)
+3. Tests writing to and reading from [workspaces](https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs)
+4. Tests that the `org-global` [context](https://circleci.com/docs/2.0/contexts) is working (*NOTE:* needs a key called `CONTEXT_END_TO_END_TEST_VAR` to exist in the `org-global` context)
+5. Tests upload/storage of [artifacts](https://circleci.com/docs/2.0/artifacts) and [test results](https://circleci.com/docs/2.0/collect-test-data)
 
-To test your installation, fork this repository and start building it on your installation of CircleCI.
+To run realitycheck, fork the repository and start building it on your installation of CircleCI.
 
 If you have more ideas for things that should tested, please submit a PR against the open-source repository on GitHub where this project is maintained: <https://github.com/circleci/realitycheck>
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
  # realitycheck
 A sample app that reality checks some basic features on your installation of CircleCI:
-1. Runs all known resource_class options
-2. Runs a machine executor & remote docker 
+1. Runs all known `resource_class` options (*NOTE:* your build instances must be large enough to accomodate these options)
+2. Runs `machine` executor & `setup_remote_docker` builds, both with and without [Docker Layer Caching](https://circleci.com/docs/2.0/docker-layer-caching)
 3. Read/write workspaces
-4. Tests that the org-global context is working (*NOTE:* needs a key called `CONTEXT_END_TO_END_TEST_VAR` to exist in the `org-global` context)
+4. Tests that the `org-global` context is working (*NOTE:* needs a key called `CONTEXT_END_TO_END_TEST_VAR` to exist in the `org-global` context)
 5. Tests writing artifacts
 
-To test your installation, clone this code and add it to your CircleCI as a project.
+To test your installation, fork this repository and start building it on your installation of CircleCI.
 
-If you have more ideas for things that should tested please submit a PR against the open source repository on GitHub where this project is maintained: <https://github.com/circleci/realitycheck>
+If you have more ideas for things that should tested, please submit a PR against the open-source repository on GitHub where this project is maintained: <https://github.com/circleci/realitycheck>
 
 See the current CI status of the main repo at <https://circleci.com/gh/circleci/workflows/realitycheck>.
 


### PR DESCRIPTION
- moved Workflows syntax to the bottom, since this is primarily a customer-facing tool & customers overwhelmingly organize their config files that way (as do we in [our own documentation](https://circleci.com/docs/2.0/sample-config))
- added a job to test `docker_layer_caching` on the `machine` executor (& updated the remote Docker DLC syntax)—although the DLC "test" is fairly cosmetic & could probably be made more expansive
- refactored YAML anchors/aliases a bit
- renamed some things for clarity
- added a bunch of vertical whitespacing 😅
- incorporated changes from 2 other now-closed PRs (`resource_class: xlarge`, multi-contexts)