### PR TITLE
Adding cache job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,8 @@ jobs:
             - ./stuff/thing
             
       - run: rm -rf ./stuff/thing
-          
+      - run: sleep 5
+      
       - restore_cache:
             keys:
               - v3-file-cache-{{ .BuildNum }}       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,11 +127,22 @@ jobs:
 
   
   save_and_restore_cache:
+  
     docker:
       - image: circleci/python
     working_directory: ~/realitycheck
     steps:
       - checkout
+      
+      - run: mkdir -p stuff
+      - run: echo 5 >./stuff/thing
+      
+      - save_cache:
+          key: v3-file-cache
+          paths:
+            - ./stuff/thing
+            
+      - run: rm -rf ./stuff/thing
           
       - restore_cache:
             keys:
@@ -139,18 +150,12 @@ jobs:
               
       - run: |
             if [[ $(< stuff/thing) != '5' ]]; then
-              echo "The cache wasn't populated"
+              exit 1
             else
               echo "The cache was populated"
             fi
       
-      - run: mkdir -p stuff
-      - run: echo 5 >./stuff/thing
-          
-      - save_cache:
-          key: v3-file-cache
-          paths:
-            - ./stuff/thing
+
   
   artifacts_test_results:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
       - run: echo 5 >./stuff/thing
       
       - save_cache:
-          key: v3-file-cache
+          key: v3-file-cache-{{ .BuildNum }}
           paths:
             - ./stuff/thing
             
@@ -146,7 +146,7 @@ jobs:
           
       - restore_cache:
             keys:
-              - v3-file-cache         
+              - v3-file-cache-{{ .BuildNum }}       
               
       - run: |
             if [[ $(< stuff/thing) != '5' ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,33 @@ jobs:
             exit 0
           fi
 
+  
+  save_and_restore_cache:
+    docker:
+      - image: circleci/python
+    working_directory: ~/realitycheck
+    steps:
+      - checkout
+          
+      - restore_cache:
+            keys:
+              - v3-file-cache         
+              
+      - run: |
+            if [[ $(< stuff/thing) != '5' ]]; then
+              echo "The cache wasn't populated"
+            else
+              echo "The cache was populated"
+            fi
+      
+      - run: mkdir -p stuff
+      - run: echo 5 >./stuff/thing
+          
+      - save_cache:
+          key: v3-file-cache
+          paths:
+            - ./stuff/thing
+  
   artifacts_test_results:
     docker:
       - image: python:3.6.0
@@ -168,6 +195,7 @@ workflows:
 
   feature_jobs:
     jobs:
+      - save_and_restore_cache
       - contexts:
           context: org-global
       - multi-contexts:


### PR DESCRIPTION
Cache job will only work after the second run, but won't fail the reality check build either way since it needs to run at least once in order to verify that it is indeed using the cache.