### PR TITLE
Iynere circle token patch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ resource_job_defaults: &resource_job_defaults
         name: verify that job ran with the requested resource_class option
         command: |
           curl \
-          "$CIRCLE_HOSTNAME/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/realitycheck/$CIRCLE_BUILD_NUM" | \
+          "$CIRCLE_HOSTNAME/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/realitycheck/$CIRCLE_BUILD_NUM?\
+          circle-token=$CIRCLE_TOKEN" | \
           jq '.picard.resource_class.class' | grep $CIRCLE_JOB
 
 remote_docker_defaults: &remote_docker_defaults

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ To run realitycheck, fork the repository and start building it on your installat
 Tests all known `resource_class` options—queries the CircleCI API to verify that jobs ran with the requested resources.
 
 - Your instances must be large enough to accomodate these options—see our [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#resource_class) for details
-- API calls require that the base URL of your CircleCI installation (e.g., https://circleci.com) is specified via a `CIRCLE_HOSTNAME` project environment variable, and that a personal API token (see `CIRCLE_HOSTNAME`/account/api URL endpoint) is stored as a `CIRCLE_TOKEN` project environment variable
+- The base URL of your CircleCI installation (e.g., https://circleci.com) must be specified via a `CIRCLE_HOSTNAME` project environment variable
+- A personal API token (see `CIRCLE_HOSTNAME`/account/api URL endpoint) must be stored as a `CIRCLE_TOKEN` project environment variable
 
 
 ### VM service workflow

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To run realitycheck, fork the repository and start building it on your installat
 Tests all known `resource_class` options—queries the CircleCI API to verify that jobs ran with the requested resources.
 
 - Your instances must be large enough to accomodate these options—see our [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#resource_class) for details
-- API calls require that the base URL of your CircleCI installation (e.g., https://circleci.com) is specified via a `CIRCLE_HOSTNAME` project environment variable
+- API calls require that the base URL of your CircleCI installation (e.g., https://circleci.com) is specified via a `CIRCLE_HOSTNAME` project environment variable, and that a personal API token (see `CIRCLE_HOSTNAME`/account/api URL endpoint) is stored as a `CIRCLE_TOKEN` project environment variable
 
 
 ### VM service workflow

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tests all known `resource_class` options—queries the CircleCI API to verify th
 
 - Your instances must be large enough to accomodate these options—see our [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#resource_class) for details
 - The base URL of your CircleCI installation (e.g., https://circleci.com) must be specified via a `CIRCLE_HOSTNAME` project environment variable
-- A personal API token (see `CIRCLE_HOSTNAME`/account/api URL endpoint) must be stored as a `CIRCLE_TOKEN` project environment variable
+- A personal API token (see `CIRCLE_HOSTNAME/account/api` URL endpoint) must be stored as a `CIRCLE_TOKEN` project environment variable
 
 
 ### VM service workflow


### PR DESCRIPTION
even an open-source repo requires a token to authenticate API calls on a hosted CircleCI installation