### PR TITLE
Use CIRCLE_PROJECT_REPONAME variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ resource_job_defaults: &resource_job_defaults
         name: verify that job ran with the requested resource_class option
         command: |
           curl -k \
-          "$CIRCLE_HOSTNAME/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/realitycheck/$CIRCLE_BUILD_NUM?\
+          "$CIRCLE_HOSTNAME/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?\
           circle-token=$CIRCLE_TOKEN" | \
           jq '.picard.resource_class.class' | grep $CIRCLE_JOB
 


### PR DESCRIPTION
 * Change the hard-coded `realitycheck` project name by the variable `CIRCLE_PROJECT_REPONAME`