### PR TITLE
Add windows tests for machine VMs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,11 @@ contexts_defaults: &contexts_defaults
   docker: [{image: 'alpine:latest'}]
   working_directory: /a/contexts/test
 
+windows_defaults: &windows_defaults
+  machine: 
+    image: windows-default
+  resource_class: windows.medium
+
 workspaces_defaults: &workspaces_defaults
   docker: [{image: 'circleci/node:latest'}]
   working_directory: ~/foo/bar
@@ -65,6 +70,11 @@ jobs:
           echo 'Done sleeping.'
     environment:
       SLEEP: 1
+
+  windows:
+    <<: *windows_defaults
+    steps:
+      - run: systeminfo
 
   remote_docker:
     <<: *remote_docker_defaults
@@ -201,6 +211,7 @@ workflows:
       - remote_docker
       - docker_layer_caching
       - machine_dlc
+      - windows
 
   feature_jobs:
     jobs:


### PR DESCRIPTION
Adding simple windows tests for machine VMs. Runs the `systeminfo` command to ensure the windows environment is running properly. This workflow will fail on systems that do not have windows configured or are on an install < 2.18.3