### PR TITLE
Add helpful message for required variables in resource_class workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,15 @@ resource_job_defaults: &resource_job_defaults
   docker:  [{image: 'circleci/ruby:2.4.1'}]
   steps:
     - run:
+        name: verify required Environment Variables
+        command: |
+          if [ -z "${CIRCLE_HOSTNAME}" -o -z "${CIRCLE_TOKEN}" ];then
+            echo "You must provide 2 Environment Variables in project settings for this job to run."
+            echo "CIRCLE_HOSTNAME: Should be the scheme://domain of your install. \"https://ci.example.com\""
+            echo "CIRCLE_TOKEN: Should be the API Key of an admin or project level with Scope:All"
+            exit 1
+          fi
+    - run:
         name: verify that job ran with the requested resource_class option
         command: |
           curl -k \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
   machine:
     machine: true
     steps:
+      - run:
+          <<: *basic_docker_build
       - run: |
           echo $SLEEP
           date


### PR DESCRIPTION
The `resource_class_jobs` workflow requires 2 variables for the host and api token.  When these are missing you get a cryptic "malformed URL" error.

This change adds a value check with helpful debug message.

BEFORE
![Screen Shot 2019-12-04 at 10 07 02 AM](https://user-images.githubusercontent.com/5262154/70154239-30e18d80-167e-11ea-909b-1d2376ed146f.png)


AFTER
![Screen Shot 2019-12-04 at 10 06 48 AM](https://user-images.githubusercontent.com/5262154/70154253-35a64180-167e-11ea-9e86-0dd0f4f8ecc8.png)
