### PR TITLE
removes trailing slash in CIRCLE_HOSTNAME to prevent parse error in job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ resource_job_defaults: &resource_job_defaults
         name: verify that job ran with the requested resource_class option
         command: |
           curl -k \
-          "$CIRCLE_HOSTNAME/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?\
+          "${CIRCLE_HOSTNAME%/}/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?\
           circle-token=$CIRCLE_TOKEN" | \
           jq '.picard.resource_class.class' | grep $CIRCLE_JOB
 


### PR DESCRIPTION
⚙️Issue
If a user has a trailing slash `/` at the end of their environment variable, `CIRCLE_HOSTNAME`, an error is thrown ↓
<img width="1704" alt="Screen Shot 2020-02-05 at 11 31 09" src="https://user-images.githubusercontent.com/20951007/73887668-9f36fd80-4831-11ea-9340-3de839df8693.png">

Error message reads: 
``` 
parse error: Invalid numeric literal at line 1, column 10
```

✅Fix
Adding a bash string manipulation line allows flexiblity for users to have or not have a trailing slash in their environment variable. 
I've added `${%/}` to the `verify that job ran with the requested resource_class option` job. This will remove any matching `/` from the end. 

❓Test 
I've tested this locally and it's gotten green builds on both having a trailing slash and not having a trailing slash. 
- [With slash](http://34.236.148.237/workflow-run/d8f5bedf-abf1-4f76-9088-22d6f35c6db1)
- [Without slash](http://34.236.148.237/workflow-run/dd402086-3317-4b0c-8cfc-af7f7e964d71)