### PR TITLE
Bump resource class image version to support TLS 1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 
 resource_job_defaults: &resource_job_defaults
-  docker:  [{image: 'circleci/ruby:2.4.1'}]
+  docker:
+    - image: 'cimg/base:2021.02-20.04'
   steps:
     - run:
         name: verify required Environment Variables


### PR DESCRIPTION
The current ruby image used has a version of curl that doesn't support TLS v1.3. This leads to failure of resource class jobs if running against a Server install that doesn't support TLSv1.2. Its reasonable, if not good practice, to configure Server this way as TLSv1.2 has some [known vulnerabilities](https://www.cloudflare.com/learning/ssl/why-use-tls-1.3/). 

This work uses a more recent image that contains a curl version that does support TLSv1.3