### PR TITLE
[server-1416] extending the executor tests in realitycheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
   medium_windows:
     machine:
       image: windows-default
-    resource_class: medium
+    resource_class: windows.medium
     steps:
       - run:
           <<: *basic_docker_build
@@ -154,7 +154,7 @@ jobs:
   large_windows:
     machine:
       image: windows-default
-    resource_class: large
+    resource_class: windows.large
     steps:
       - run:
           <<: *basic_docker_build
@@ -170,7 +170,7 @@ jobs:
   xlarge_windows:
     machine:
       image: windows-default
-    resource_class: xlarge
+    resource_class: windows.xlarge
     steps:
       - run:
           <<: *basic_docker_build
@@ -186,7 +186,7 @@ jobs:
   2xlarge_windows:
     machine:
       image: windows-default
-    resource_class: 2xlarge
+    resource_class: windows.2xlarge
     steps:
       - run:
           <<: *basic_docker_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,35 @@ jobs:
     <<: *resource_job_defaults
     resource_class: xlarge
 
-  # vm jobs
-  machine:
+  # check if EC2
+  run_arm_jobs_if_ec2:
     machine: true
+    steps:
+      - run: |
+          result=$(curl http://169.254.169.254/latest/meta-data/instance-type)
+          if [[ $result == *"Not Found"* ]]; then exit 1; fi
+    environment:
+      SLEEP: 1
+
+  # linux jobs
+  medium_linux:
+    machine: true
+    resource_class: medium
+    steps:
+      - run:
+          <<: *basic_docker_build
+      - run: |
+          echo $SLEEP
+          date
+          sleep $SLEEP
+          date
+          echo 'Done sleeping.'
+    environment:
+      SLEEP: 1
+  
+  large_linux:
+    machine: true
+    resource_class: large
     steps:
       - run:
           <<: *basic_docker_build
@@ -78,6 +104,143 @@ jobs:
     environment:
       SLEEP: 1
 
+  xlarge_linux:
+    machine: true
+    resource_class: xlarge
+    steps:
+      - run:
+          <<: *basic_docker_build
+      - run: |
+          echo $SLEEP
+          date
+          sleep $SLEEP
+          date
+          echo 'Done sleeping.'
+    environment:
+      SLEEP: 1
+
+  2xlarge_linux:
+    machine: true
+    resource_class: 2xlarge
+    steps:
+      - run:
+          <<: *basic_docker_build
+      - run: |
+          echo $SLEEP
+          date
+          sleep $SLEEP
+          date
+          echo 'Done sleeping.'
+    environment:
+      SLEEP: 1
+
+  # windows jobs
+  medium_windows:
+    machine:
+      image: windows-default
+    resource_class: medium
+    steps:
+      - run:
+          <<: *basic_docker_build
+      - run: |
+          echo $SLEEP
+          date
+          sleep $SLEEP
+          date
+          echo 'Done sleeping.'
+    environment:
+      SLEEP: 1
+
+  large_windows:
+    machine:
+      image: windows-default
+    resource_class: large
+    steps:
+      - run:
+          <<: *basic_docker_build
+      - run: |
+          echo $SLEEP
+          date
+          sleep $SLEEP
+          date
+          echo 'Done sleeping.'
+    environment:
+      SLEEP: 1
+
+  xlarge_windows:
+    machine:
+      image: windows-default
+    resource_class: xlarge
+    steps:
+      - run:
+          <<: *basic_docker_build
+      - run: |
+          echo $SLEEP
+          date
+          sleep $SLEEP
+          date
+          echo 'Done sleeping.'
+    environment:
+      SLEEP: 1
+
+  2xlarge_windows:
+    machine:
+      image: windows-default
+    resource_class: 2xlarge
+    steps:
+      - run:
+          <<: *basic_docker_build
+      - run: |
+          echo $SLEEP
+          date
+          sleep $SLEEP
+          date
+          echo 'Done sleeping.'
+    environment:
+      SLEEP: 1
+
+  windows-medium:
+    machine:
+      image: windows-default # Windows machine image
+    resource_class: windows.medium
+    steps:
+      - checkout
+      - run: systeminfo
+
+  # arm jobs
+  medium_arm:
+    machine:
+      image: arm-default
+    resource_class: arm.medium
+    steps:
+      - run:
+          <<: *basic_docker_build
+      - run: |
+          echo $SLEEP
+          date
+          sleep $SLEEP
+          date
+          echo 'Done sleeping.'
+    environment:
+      SLEEP: 1
+
+  large_arm:
+    machine:
+      image: arm-default
+    resource_class: arm.large
+    steps:
+      - run:
+          <<: *basic_docker_build
+      - run: |
+          echo $SLEEP
+          date
+          sleep $SLEEP
+          date
+          echo 'Done sleeping.'
+    environment:
+      SLEEP: 1
+
+  # vm jobs
   remote_docker:
     <<: *remote_docker_defaults
     steps:
@@ -209,7 +372,6 @@ workflows:
 
   vm_jobs:
     jobs:
-      - machine
       - remote_docker
       - docker_layer_caching
       - machine_dlc
@@ -227,3 +389,26 @@ workflows:
             - write_workspace
       - artifacts_test_results
 
+  linux_jobs:
+    jobs:
+      - medium_linux
+      - large_linux
+      - xlarge_linux
+      - 2xlarge_linux
+
+  windows_jobs:
+    jobs:
+      - medium_windows
+      - large_windows
+      - xlarge_windows
+      - 2xlarge_windows
+
+  arm_jobs:
+    jobs:
+      - run_arm_jobs_if_ec2
+      - medium_arm:
+          requires:
+            - run_arm_jobs_if_ec2
+      - large_arm:
+          requires:
+            - run_arm_jobs_if_ec2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,64 +140,32 @@ jobs:
       image: windows-default
     resource_class: windows.medium
     steps:
-      - run:
-          <<: *basic_docker_build
-      - run: |
-          echo $SLEEP
-          date
-          sleep $SLEEP
-          date
-          echo 'Done sleeping.'
-    environment:
-      SLEEP: 1
+      - checkout
+      - run: systeminfo
 
   large_windows:
     machine:
       image: windows-default
     resource_class: windows.large
     steps:
-      - run:
-          <<: *basic_docker_build
-      - run: |
-          echo $SLEEP
-          date
-          sleep $SLEEP
-          date
-          echo 'Done sleeping.'
-    environment:
-      SLEEP: 1
+      - checkout
+      - run: systeminfo
 
   xlarge_windows:
     machine:
       image: windows-default
     resource_class: windows.xlarge
     steps:
-      - run:
-          <<: *basic_docker_build
-      - run: |
-          echo $SLEEP
-          date
-          sleep $SLEEP
-          date
-          echo 'Done sleeping.'
-    environment:
-      SLEEP: 1
+      - checkout
+      - run: systeminfo
 
   2xlarge_windows:
     machine:
       image: windows-default
     resource_class: windows.2xlarge
     steps:
-      - run:
-          <<: *basic_docker_build
-      - run: |
-          echo $SLEEP
-          date
-          sleep $SLEEP
-          date
-          echo 'Done sleeping.'
-    environment:
-      SLEEP: 1
+      - checkout
+      - run: systeminfo
 
   windows-medium:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,6 @@ jobs:
       - run: |
           result=$(curl http://169.254.169.254/latest/meta-data/instance-type)
           if [[ $result == *"Not Found"* ]]; then exit 1; fi
-    environment:
-      SLEEP: 1
 
   # linux jobs
   medium_linux:


### PR DESCRIPTION
We would like to extend the realitycheck's tests to include windows, linux and arm executors

https://circleci.atlassian.net/browse/SERVER-1416

Caveats:
- ARM is only supported in AWS at this time and is expected to fail on GCP
- Windows executors require the user to provide an AMI as we currently don't provide defaults.