### PR TITLE
[SERVER-2194] Add job for verifying the windows executor resource classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,13 @@ version: 2.1
 
 executors:
   default:
+    parameters:
+      resource_class:
+        type: string
+        default: "small"
     docker:
       - image: 'cimg/base:2021.02-20.04'
+    resource_class: <<parameters.resource_class>>
 
 commands:
   verify_resource_class:
@@ -24,11 +29,6 @@ commands:
             "${CIRCLE_HOSTNAME%/}/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?\
             circle-token=$CIRCLE_TOKEN" | \
             jq '.picard.resource_class.class' | grep $CIRCLE_JOB
-
-resource_job_defaults: &resource_job_defaults
-  executor: default
-  steps:
-    - verify_resource_class
 
 remote_docker_defaults: &remote_docker_defaults
   docker: [{image: 'docker:17.06-git'}]
@@ -51,26 +51,17 @@ workspaces_defaults: &workspaces_defaults
   working_directory: ~/foo/bar
 
 jobs:
-  # resource class jobs
-  small: # 1 vCPU, 2GB RAM
-    <<: *resource_job_defaults
-    resource_class: small
-
-  medium: # 2 vCPUs, 4GB RAM
-    <<: *resource_job_defaults
-    resource_class: medium
-
-  mediumplus: # 3 vCPUs, 6GB RAM
-    <<: *resource_job_defaults
-    resource_class: medium+
-
-  large: # 4 vCPUs, 8GB RAM
-    <<: *resource_job_defaults
-    resource_class: large
-
-  xlarge: # 8 vCPUs, 16GB RAM
-    <<: *resource_job_defaults
-    resource_class: xlarge
+  # docker resource class jobs
+  docker_resource_class:
+    parameters:
+      resource_class:
+        type: string
+        default: "small"
+    executor:
+      name: default
+      resource_class: <<parameters.resource_class>>
+    steps:
+      - verify_resource_class
   
   check_if_environment_is_aws:
     executor: default
@@ -271,11 +262,10 @@ workflows:
   version: 2
   resource_class_jobs:
     jobs:
-      - small
-      - medium
-      - mediumplus
-      - large
-      - xlarge
+     - docker_resource_class:d
+        matrix:
+          parameters:
+            resource_class: [small, medium, medium+, large, xlarge]
 
   vm_jobs:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workspaces_defaults: &workspaces_defaults
 
 jobs:
   # job definition for verifying the resource_class per each executor_type
-  executor_resource_class_job:
+  executor_resource_class:
     parameters:
       resource_class:
         type: string
@@ -317,7 +317,7 @@ jobs:
 workflows:
   docker_resource_class_jobs:
     jobs:
-      - executor_resource_class_job:
+      - executor_resource_class:
           matrix:
             parameters:
               resource_class: [small, medium, medium+, large, xlarge]
@@ -326,7 +326,7 @@ workflows:
   windows_resource_class_jobs:
     jobs:
       - check_if_windows_is_enabled
-      - executor_resource_class_job:
+      - executor_resource_class:
           matrix:
             parameters:
               resource_class: [windows.medium, windows.large, windows.xlarge]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 executors:
-  default:
+  docker: # Docker using the Base Convenience Image
     parameters:
       resource_class:
         type: string
@@ -58,13 +58,13 @@ jobs:
         type: string
         default: "small"
     executor:
-      name: default
+      name: docker
       resource_class: <<parameters.resource_class>>
     steps:
       - verify_resource_class
   
   check_if_environment_is_aws:
-    executor: default
+    executor: docker
     steps:
       - run:
           name: Verify AWS Environment
@@ -79,7 +79,7 @@ jobs:
             fi
 
   check_if_environment_is_gcp:
-    executor: default
+    executor: docker
     steps:
       - run:
           name: Verify GCP Environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ workflows:
       - executor_resource_class_job:
           matrix:
             parameters:
-              resource_class: [windows.medium]
+              resource_class: [windows.medium, windows.large]
               executor_type: [windows]
 
   vm_jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ workflows:
       - executor_resource_class_job:
           matrix:
             parameters:
-              resource_class: [windows.medium, windows.large, windows.xlarge, windows.2xlarge]
+              resource_class: [windows.medium]
               executor_type: [windows]
 
   vm_jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
             - run:
                 name: Verify that job ran with the requested resource_class option
                 command: |
-                  $job = Invoke-RestMethod -URI https://$env:CIRCLE_HOSTNAME/api/v2/project/gh/$env:CIRCLE_PROJECT_USERNAME/$env:CIRCLE_PROJECT_REPONAME/job/$env:CIRCLE_BUILD_NUM \
+                  $job = Invoke-RestMethod -URI https://$env:CIRCLE_HOSTNAME/api/v2/project/gh/$env:CIRCLE_PROJECT_USERNAME/$env:CIRCLE_PROJECT_REPONAME/job/$env:CIRCLE_BUILD_NUM `
                     -Headers @{ 'Circle-Token' = '$env:CIRCLE_TOKEN' }
                   $job.executor.resource_class | Select-String -Pattern '<<parameters.resource_class>>'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ executors:
     resource_class: <<parameters.resource_class>>
 
 commands:
+  # resource_class verification commands to execute depending on executor_type
   verify_resource_class:
     parameters:
       resource_class:
@@ -80,19 +81,23 @@ workspaces_defaults: &workspaces_defaults
   working_directory: ~/foo/bar
 
 jobs:
-  # docker resource class jobs
-  docker_resource_class:
+  # job definition for verifying the resource_class per each executor_type
+  executor_resource_class_job:
     parameters:
       resource_class:
         type: string
         default: "small"
+      executor_type:
+        type: string
+        default: "docker"
     executor:
-      name: docker
+      name: <<parameters.executor_type>>
       resource_class: <<parameters.resource_class>>
     steps:
       - verify_resource_class:
           resource_class: <<parameters.resource_class>>
-  
+          executor_type: <<parameters.executor_type>>
+
   check_if_environment_is_aws:
     executor: docker
     steps:
@@ -291,11 +296,16 @@ jobs:
 workflows:
   resource_class_jobs:
     jobs:
-     - docker_resource_class:
-        matrix:
-          parameters:
-            resource_class: [small, medium, medium+, large, xlarge]
-
+      - executor_resource_class_job:
+          matrix:
+            parameters:
+              resource_class: [small, medium, medium+, large, xlarge]
+              executor_type: [docker] # default, but re-defining for clarity
+      - executor_resource_class_job:
+          matrix:
+            parameters:
+              resource_class: [medium, large, xlarge, 2xlarge]
+              executor_type: [windows]
   vm_jobs:
     jobs:
       - machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,25 +5,30 @@ executors:
     docker:
       - image: 'cimg/base:2021.02-20.04'
 
+commands:
+  verify_resource_class:
+    steps:
+      - run:
+          name: verify required Environment Variables
+          command: |
+            if [ -z "${CIRCLE_HOSTNAME}" -o -z "${CIRCLE_TOKEN}" ];then
+              echo "You must provide 2 Environment Variables in project settings for this job to run."
+              echo "CIRCLE_HOSTNAME: Should be the scheme://domain of your install. \"https://ci.example.com\""
+              echo "CIRCLE_TOKEN: Should be the API Key of an admin or project level with Scope:All"
+              exit 1
+            fi
+      - run:
+          name: Verify that job ran with the requested resource_class option
+          command: |
+            curl -k \
+            "${CIRCLE_HOSTNAME%/}/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?\
+            circle-token=$CIRCLE_TOKEN" | \
+            jq '.picard.resource_class.class' | grep $CIRCLE_JOB
+
 resource_job_defaults: &resource_job_defaults
   executor: default
   steps:
-    - run:
-        name: verify required Environment Variables
-        command: |
-          if [ -z "${CIRCLE_HOSTNAME}" -o -z "${CIRCLE_TOKEN}" ];then
-            echo "You must provide 2 Environment Variables in project settings for this job to run."
-            echo "CIRCLE_HOSTNAME: Should be the scheme://domain of your install. \"https://ci.example.com\""
-            echo "CIRCLE_TOKEN: Should be the API Key of an admin or project level with Scope:All"
-            exit 1
-          fi
-    - run:
-        name: verify that job ran with the requested resource_class option
-        command: |
-          curl -k \
-          "${CIRCLE_HOSTNAME%/}/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?\
-          circle-token=$CIRCLE_TOKEN" | \
-          jq '.picard.resource_class.class' | grep $CIRCLE_JOB
+    - verify_resource_class
 
 remote_docker_defaults: &remote_docker_defaults
   docker: [{image: 'docker:17.06-git'}]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,10 +259,9 @@ jobs:
           path: test-results
 
 workflows:
-  version: 2
   resource_class_jobs:
     jobs:
-     - docker_resource_class:d
+     - docker_resource_class:
         matrix:
           parameters:
             resource_class: [small, medium, medium+, large, xlarge]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,9 @@ commands:
             - run:
                 name: Verify that job ran with the requested resource_class option
                 command: |
-                  # Commands are run in a Windows virtual machine environment
-                  Write-Host 'Hello, Windows'
+                  $job = Invoke-RestMethod -URI https://$env:CIRCLE_HOSTNAME/api/v2/project/gh/$env:CIRCLE_PROJECT_USERNAME/$env:CIRCLE_PROJECT_REPONAME/job/$env:CIRCLE_BUILD_NUM \
+                    -Headers @{ 'Circle-Token' = '$env:CIRCLE_TOKEN' }
+                  $job.executor.resource_class | Select-String -Pattern '<<parameters.resource_class>>'
 
 remote_docker_defaults: &remote_docker_defaults
   docker: [{image: 'docker:17.06-git'}]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,10 +142,10 @@ jobs:
     executor: docker
     steps:
       - run:
-          name: Verify if Windows enabled env flag is set
+          name: Verify if Windows enabled env flag is set to true
           command: |
-            if [ -z "${CIRCLE_WINDOWS_EXECUTOR}" ];then
-              echo "Windows executor environment flag is not set. Cancelling downstream workflow."
+            if [[ "${CIRCLE_WINDOWS_EXECUTOR}" != "true" ]]; then
+              echo "Windows executor environment flag is not set to \"true\". Cancelling downstream workflow."
               curl -X POST "${CIRCLE_HOSTNAME%/}/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel?circle-token=$CIRCLE_TOKEN"
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ workflows:
       - executor_resource_class_job:
           matrix:
             parameters:
-              resource_class: [medium, large, xlarge, 2xlarge]
+              resource_class: [windows.medium, windows.large, windows.xlarge, windows.2xlarge]
               executor_type: [windows]
   vm_jobs:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ workflows:
       - executor_resource_class_job:
           matrix:
             parameters:
-              resource_class: [windows.medium, windows.large]
+              resource_class: [windows.medium, windows.large, windows.xlarge]
               executor_type: [windows]
           requires:
             - check_if_windows_is_enabled

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ executors:
 
 commands:
   verify_resource_class:
+    parameters:
+      resource_class:
+        type: string
+        default: "small"
     steps:
       - run:
           name: verify required Environment Variables
@@ -28,7 +32,7 @@ commands:
             curl -k \
             "${CIRCLE_HOSTNAME%/}/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?\
             circle-token=$CIRCLE_TOKEN" | \
-            jq '.picard.resource_class.class' | grep $CIRCLE_JOB
+            jq '.picard.resource_class.class' | grep <<parameters.resource_class>>
 
 remote_docker_defaults: &remote_docker_defaults
   docker: [{image: 'docker:17.06-git'}]
@@ -61,7 +65,8 @@ jobs:
       name: docker
       resource_class: <<parameters.resource_class>>
     steps:
-      - verify_resource_class
+      - verify_resource_class:
+          resource_class: <<parameters.resource_class>>
   
   check_if_environment_is_aws:
     executor: docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
     <<: *resource_job_defaults
     resource_class: medium
 
-  medium+: # 3 vCPUs, 6GB RAM
+  mediumplus: # 3 vCPUs, 6GB RAM
     <<: *resource_job_defaults
     resource_class: medium+
 
@@ -268,7 +268,7 @@ workflows:
     jobs:
       - small
       - medium
-      - medium+
+      - mediumplus
       - large
       - xlarge
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,17 @@ jobs:
               curl -X POST "${CIRCLE_HOSTNAME%/}/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel?circle-token=$CIRCLE_TOKEN"
             fi
 
+  check_if_windows_is_enabled:
+    executor: docker
+    steps:
+      - run:
+          name: Verify if Windows enabled env flag is set
+          command: |
+            if [ -z "${CIRCLE_WINDOWS_EXECUTOR}" ];then
+              echo "Windows executor environment flag is not set. Cancelling downstream workflow."
+              curl -X POST "${CIRCLE_HOSTNAME%/}/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel?circle-token=$CIRCLE_TOKEN"
+            fi
+
   # vm jobs
   machine:
     machine: true
@@ -314,11 +325,14 @@ workflows:
 
   windows_resource_class_jobs:
     jobs:
+      - check_if_windows_is_enabled
       - executor_resource_class_job:
           matrix:
             parameters:
               resource_class: [windows.medium, windows.large]
               executor_type: [windows]
+          requires:
+            - check_if_windows_is_enabled
 
   vm_jobs:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,19 +30,19 @@ commands:
         type: string
         default: "docker"
     steps:
-      - run:
-          name: verify required Environment Variables
-          command: |
-            if [ -z "${CIRCLE_HOSTNAME}" -o -z "${CIRCLE_TOKEN}" ];then
-              echo "You must provide 2 Environment Variables in project settings for this job to run."
-              echo "CIRCLE_HOSTNAME: Should be the scheme://domain of your install. \"https://ci.example.com\""
-              echo "CIRCLE_TOKEN: Should be the API Key of an admin or project level with Scope:All"
-              exit 1
-            fi
       - when:
           condition:
             equal: [ "docker", << parameters.executor_type >> ]
           steps:
+            - run:
+                name: verify required Environment Variables
+                command: |
+                  if [ -z "${CIRCLE_HOSTNAME}" -o -z "${CIRCLE_TOKEN}" ];then
+                    echo "You must provide 2 Environment Variables in project settings for this job to run."
+                    echo "CIRCLE_HOSTNAME: Should be the scheme://domain of your install. \"https://ci.example.com\""
+                    echo "CIRCLE_TOKEN: Should be the API Key of an admin or project level with Scope:All"
+                    exit 1
+                  fi
             - run:
                 name: Verify that job ran with the requested resource_class option
                 command: |
@@ -54,6 +54,15 @@ commands:
           condition:
             equal: [ "windows", << parameters.executor_type >> ]
           steps:
+            - run:
+                name: verify required Environment Variables
+                command: |
+                  if (!((Test-Path env:CIRCLE_HOSTNAME) -and (Test-Path env:CIRCLE_TOKEN))) {
+                    Write-Host "You must provide 2 Environment Variables in project settings for this job to run."
+                    Write-Host "CIRCLE_HOSTNAME: Should be the scheme://domain of your install. "https://ci.example.com""
+                    Write-Host "CIRCLE_TOKEN: Should be the API Key of an admin or project level with Scope:All"
+                    Exit 1
+                  }
             - run:
                 name: Verify that job ran with the requested resource_class option
                 command: |
@@ -294,18 +303,22 @@ jobs:
           path: test-results
 
 workflows:
-  resource_class_jobs:
+  docker_resource_class_jobs:
     jobs:
       - executor_resource_class_job:
           matrix:
             parameters:
               resource_class: [small, medium, medium+, large, xlarge]
               executor_type: [docker] # default, but re-defining for clarity
+
+  windows_resource_class_jobs:
+    jobs:
       - executor_resource_class_job:
           matrix:
             parameters:
               resource_class: [windows.medium, windows.large, windows.xlarge, windows.2xlarge]
               executor_type: [windows]
+
   vm_jobs:
     jobs:
       - machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ commands:
       resource_class:
         type: string
         default: "small"
+      executor_type:
+        type: string
+        default: "docker"
     steps:
       - run:
           name: verify required Environment Variables
@@ -35,13 +38,26 @@ commands:
               echo "CIRCLE_TOKEN: Should be the API Key of an admin or project level with Scope:All"
               exit 1
             fi
-      - run:
-          name: Verify that job ran with the requested resource_class option
-          command: |
-            curl -k \
-            "${CIRCLE_HOSTNAME%/}/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?\
-            circle-token=$CIRCLE_TOKEN" | \
-            jq '.picard.resource_class.class' | grep <<parameters.resource_class>>
+      - when:
+          condition:
+            equal: [ "docker", << parameters.executor_type >> ]
+          steps:
+            - run:
+                name: Verify that job ran with the requested resource_class option
+                command: |
+                  curl -k \
+                  "${CIRCLE_HOSTNAME%/}/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM?\
+                  circle-token=$CIRCLE_TOKEN" | \
+                  jq '.picard.resource_class.class' | grep <<parameters.resource_class>>
+      - when:
+          condition:
+            equal: [ "windows", << parameters.executor_type >> ]
+          steps:
+            - run:
+                name: Verify that job ran with the requested resource_class option
+                command: |
+                  # Commands are run in a Windows virtual machine environment
+                  Write-Host 'Hello, Windows'
 
 remote_docker_defaults: &remote_docker_defaults
   docker: [{image: 'docker:17.06-git'}]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,15 @@ executors:
     docker:
       - image: 'cimg/base:2021.02-20.04'
     resource_class: <<parameters.resource_class>>
+  windows:  # Windows using the default windows image
+    parameters:
+      resource_class:
+        type: string
+        default: "medium"
+    machine:
+      image: windows-default
+      shell: 'powershell.exe -ExecutionPolicy Bypass'
+    resource_class: <<parameters.resource_class>>
 
 commands:
   verify_resource_class:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,9 @@ commands:
             - run:
                 name: Verify that job ran with the requested resource_class option
                 command: |
-                  $job = Invoke-RestMethod -URI https://$env:CIRCLE_HOSTNAME/api/v2/project/gh/$env:CIRCLE_PROJECT_USERNAME/$env:CIRCLE_PROJECT_REPONAME/job/$env:CIRCLE_BUILD_NUM `
-                    -Headers @{ 'Circle-Token' = '$env:CIRCLE_TOKEN' }
-                  $job.executor.resource_class | Select-String -Pattern '<<parameters.resource_class>>'
+                  $job = Invoke-RestMethod -URI "$env:CIRCLE_HOSTNAME/api/v2/project/gh/$env:CIRCLE_PROJECT_USERNAME/$env:CIRCLE_PROJECT_REPONAME/job/$env:CIRCLE_BUILD_NUM" `
+                    -Headers @{ "Circle-Token" = "$env:CIRCLE_TOKEN" }
+                  $job.executor.resource_class | Select-String -Pattern "<<parameters.resource_class>>"
 
 remote_docker_defaults: &remote_docker_defaults
   docker: [{image: 'docker:17.06-git'}]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,12 @@
-version: 2
+version: 2.1
+
+executors:
+  default:
+    docker:
+      - image: 'cimg/base:2021.02-20.04'
 
 resource_job_defaults: &resource_job_defaults
-  docker:
-    - image: 'cimg/base:2021.02-20.04'
+  executor: default
   steps:
     - run:
         name: verify required Environment Variables
@@ -64,8 +68,7 @@ jobs:
     resource_class: xlarge
   
   check_if_environment_is_aws:
-    docker:
-    - image: 'cimg/base:2021.02-20.04'
+    executor: default
     steps:
       - run:
           name: Verify AWS Environment
@@ -80,8 +83,7 @@ jobs:
             fi
 
   check_if_environment_is_gcp:
-    docker:
-    - image: 'cimg/base:2021.02-20.04'
+    executor: default
     steps:
       - run:
           name: Verify GCP Environment

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install and run reality check on your CircleCI Server installation, follow th
 
 5. Set the environment variable in your project with the name `CIRCLE_CLOUD_PROVIDER` as either `gcp`, `aws`, or `other`. depending on your installation.
 
-6. You can __optionally__ set `CIRCLE_WINDOWS_EXECUTOR` to `true` in order to run a set of verification jobs for the windows execution environment. This requires a supported CircleCI Windows image.
+6. You can __optionally__ set `CIRCLE_WINDOWS_EXECUTOR` to `true` in order to run a set of verification jobs for the windows execution environment. This requires a supported CircleCI Windows image, see instructions in [CircleCI-Public/circleci-server-windows-image-builder](https://github.com/CircleCI-Public/circleci-server-windows-image-builder).
 
 7. Configure the following contexts and keys (their values can be anything). Docs on how to set up contexts [can be found here](https://circleci.com/docs/2.0/contexts/).
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install and run reality check on your CircleCI Server installation, follow th
 
 5. Set the environment variable in your project with the name `CIRCLE_CLOUD_PROVIDER` as either `gcp`, `aws`, or `other`. depending on your installation.
 
-6. You can __optionally__ set `CIRCLE_WINDOWS_EXECUTOR` to `true` in order to run a set of verficiation jobs for the windows execution environment. This requires a supported CircleCI Windows image.
+6. You can __optionally__ set `CIRCLE_WINDOWS_EXECUTOR` to `true` in order to run a set of verification jobs for the windows execution environment. This requires a supported CircleCI Windows image.
 
 7. Configure the following contexts and keys (their values can be anything). Docs on how to set up contexts [can be found here](https://circleci.com/docs/2.0/contexts/).
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ To install and run reality check on your CircleCI Server installation, follow th
 
 5. Set the environment variable in your project with the name `CIRCLE_CLOUD_PROVIDER` as either `gcp`, `aws`, or `other`. depending on your installation.
 
-6. Configure the following contexts and keys (their values can be anything). Docs on how to set up contexts [can be found here](https://circleci.com/docs/2.0/contexts/).
+6. You can __optionally__ set `CIRCLE_WINDOWS_EXECUTOR` to `true` in order to run a set of verficiation jobs for the windows execution environment. This requires a supported CircleCI Windows image.
+
+7. Configure the following contexts and keys (their values can be anything). Docs on how to set up contexts [can be found here](https://circleci.com/docs/2.0/contexts/).
 
 Context Name       | Environment Variable Key Name  | Value   
 -------------------|------------------------------- |-----------------------------
@@ -34,6 +36,7 @@ Context Name       | Environment Variable Key Name  | Value
 CIRCLE_TOKEN=123456789-personal-access-token
 CIRCLE_HOSTNAME=https://aws-server-install.example.com
 CIRCLE_CLOUD_PROVIDER=aws
+CIRCLE_WINDOWS_EXECUTOR=true # Optional, only if using a Windowws AMI
 
 # org-global context environment variables
 CONTEXT_END_TO_END_TEST_VAR=1
@@ -48,6 +51,7 @@ MULTI_CONTEXT_END_TO_END_VAR=1
 CIRCLE_TOKEN=123456789-personal-access-token
 CIRCLE_HOSTNAME=https://gcp-server-install.example.com
 CIRCLE_CLOUD_PROVIDER=gcp
+CIRCLE_WINDOWS_EXECUTOR=true # Optional, only if using a Windows AMI
 
 # org-global context environment variables
 CONTEXT_END_TO_END_TEST_VAR=1


### PR DESCRIPTION
The purpose of this PR is to add support for testing the various resource classes available for the [Windows execution environment](https://circleci.com/docs/configuration-reference/#windows-execution-environment). See ticket: [SERVER-2194](https://circleci.atlassian.net/browse/SERVER-2194).

- Update to config version 2.1 and refactor docker resource class config block to use [reusable configuration](https://circleci.com/docs/reusing-config/).
- Define docker and windows executors
- Define `verify_resource_class` command for performing verification actions per specific executor.
- Add `executor_resource_class` job which accepts `executor_type` and `resource_class` params.
- Add `CIRCLE_WINDOWS_EXECUTOR` variable for checking if the windows workflows should be executed.
- Update readme.
