### PR TITLE
config: fix parser/validator warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,8 @@ jobs:
 
   # vm jobs
   machine:
-    machine: true
+    machine:
+      image: ubuntu-2204:current
     steps:
       - run:
           <<: *basic_docker_build


### PR DESCRIPTION
The new orb-service parser/validator flags `machine: true` (no image) as `machine-image-unspecified`. Replaced with an explicit `ubuntu-2204:current`, which is what the platform was already defaulting to.